### PR TITLE
Added shadow casting setting to LOD variants

### DIFF
--- a/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
@@ -255,6 +255,7 @@ func assign_LOD_variant(max_LOD_index:int, LOD_max_distance:float, LOD_kill_dist
 	# But non-leaves do not have an MMI and can't spawn spatials
 	if is_leaf:
 		MMI.multimesh.mesh = shared_LOD_variants[LOD_index].mesh
+		MMI.cast_shadow = shared_LOD_variants[LOD_index].shadow_casting_mode
 		clear_and_spawn_all_member_spatials(last_LOD_index)
 
 

--- a/addons/dreadpon.spatial_gardener/gardener/gardener.gd
+++ b/addons/dreadpon.spatial_gardener/gardener/gardener.gd
@@ -442,6 +442,9 @@ func on_greenhouse_prop_action_executed_on_LOD_variant(prop_action:PropAction, f
 		"spawned_spatial":
 			if prop_action is PA_PropSet || prop_action is PA_PropEdit:
 				arborist.on_LOD_variant_prop_changed_spawned_spatial(plant_index, mesh_index, final_val)
+		"shadow_casting_mode":
+			if prop_action is PA_PropSet || prop_action is PA_PropEdit:
+				arborist.recenter_octree(plant_state, plant_index) #to force a refresh
 
 
 # A request to reconfigure an octree

--- a/addons/dreadpon.spatial_gardener/greenhouse/greenhouse_LOD_variant.gd
+++ b/addons/dreadpon.spatial_gardener/greenhouse/greenhouse_LOD_variant.gd
@@ -13,6 +13,8 @@ var Globals = preload("../utility/globals.gd")
 var mesh:Mesh = null
 var spawned_spatial:PackedScene = null
 
+#Toggle for shadow casting mode on multimeshes
+var shadow_casting_mode:int = GeometryInstance.SHADOW_CASTING_SETTING_ON
 
 
 
@@ -52,6 +54,9 @@ func _create_input_field(_base_control:Control, _resource_previewer, prop:String
 				"_resource_previewer": _resource_previewer,
 				}
 			input_field = UI_IF_ThumbnailObject.new(spawned_spatial, "Spawned Spatial", prop, settings)
+		"shadow_casting_mode":
+			var settings := {"enum_list": ["Off", "On"]}
+			input_field = UI_IF_Enum.new(shadow_casting_mode, "Shadow Casting Mode", prop, settings)
 	
 	return input_field
 
@@ -72,6 +77,8 @@ func _set(prop, val):
 			mesh = val
 		"spawned_spatial":
 			spawned_spatial = val
+		"shadow_casting_mode":
+			shadow_casting_mode = val
 		_:
 			return_val = false
 	
@@ -87,6 +94,8 @@ func _get(prop):
 			return mesh
 		"spawned_spatial":
 			return spawned_spatial
+		"shadow_casting_mode":
+			return shadow_casting_mode
 	
 	return null
 
@@ -96,6 +105,7 @@ func _get_property_list():
 	var props := [
 			prop_dict["mesh"],
 			prop_dict["spawned_spatial"],
+			prop_dict["shadow_casting_mode"]
 		]
 	
 	return props
@@ -115,6 +125,14 @@ func _get_prop_dictionary():
 			"usage": PROPERTY_USAGE_DEFAULT,
 			"hint": PROPERTY_HINT_NONE,
 		},
+		"shadow_casting_mode":
+		{
+			"name": "shadow_casting_mode",
+			"type": TYPE_INT,
+			"usage": PROPERTY_USAGE_DEFAULT,
+			"hint": PROPERTY_HINT_ENUM,
+			"hint_string": "Off,On"
+		}
 	}
 
 
@@ -132,5 +150,7 @@ func get_prop_tooltip(prop:String) -> String:
 				+ "But if all your LODs reference the same PackedScene - they will persist across the LOD changes and won't cause any lag spikes\n" \
 				+ "The alternative would be to optimise yout octrees to contain only a small amount of Spawned Spatials - 10-20 at most\n" \
 				+ "Then the process of switching LODs will go a lot smoother"
-	
+		"shadow_casting_mode":
+			return "Whether this specific LOD is enabled for shadow casting\n" \
+				+ "Disabling slightly improves performance and is recommended for higher LODs (far away)"
 	return ""


### PR DESCRIPTION
This is an attempt to implement the feature request: https://github.com/dreadpon/godot_spatial_gardener/issues/15
It allows setting cast_shadows of MMI for each LOD entry separately, which is often desired for active instances further away.
I couldn't figure out how to properly rebuild the state, so i just forced an octree-rebuild, which unfortunately by default doesn't properly rebuild the visual state (instances are invisible afterwards) and requires a scene reload or reapply-brush painting, but atleast correctly applies the changed LOD variant settings it seems.
The missing visuals rebuild also happens when re-assigning new meshes to an LOD variant, if the assigned meshes were the same in all variants before.
It would probably help to have a general rebuild method that also restores the rendered visuals without rebuilding or recentering the octree. Not sure if that's possible though, as i can see the MMIs possibly being invalidated by changed meshes.