### PR TITLE
Lod shadow casting cleanup

### DIFF
--- a/addons/dreadpon.spatial_gardener/arborist/arborist.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/arborist.gd
@@ -202,6 +202,13 @@ func on_LOD_variant_prop_changed_spawned_spatial(plant_index:int, mesh_index:int
 	octree_manager.reset_member_spatials()
 
 
+# Make sure LODs in OctreeNodes correspond to their active_LOD_index
+# This is the preffered way to 'refresh' MMIs inside OctreeNodes
+func set_LODs_to_active_index(plant_index:int):
+	var octree_manager:MMIOctreeManager = octree_managers[plant_index]
+	octree_manager.set_LODs_to_active_index()
+
+
 # Initialize an OctreeManager for a given plant
 func add_plant_octree_manager(plant_state, plant_index:int):
 	var octree_manager:MMIOctreeManager = MMIOctreeManager.new()
@@ -355,6 +362,7 @@ func _action_apply_changes(changes):
 #-------------------------------------------------------------------------------
 
 
+# Replace LOD_Variants inside of a shared array owned by this OctreeManager
 func refresh_octree_shared_LOD_variants(plant_index:int, LOD_variants:Array):
 	if octree_managers.size() > plant_index:
 		octree_managers[plant_index].set_LOD_variants(LOD_variants)

--- a/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_manager.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_manager.gd
@@ -290,7 +290,11 @@ func set_LOD_variant(variant, index:int):
 # Up-to-date LOD variants of an OctreeNode
 func set_LOD_variant_spawned_spatial(variant, index:int):
 	# No need to manually set spawned_spatial, it will be inherited from parent resource
-	LOD_variants[index].spawned_spatial = variant
+	
+	# /\ I don't quite remember what this comment meant, but since LOD_Variants are shared
+	# It seems to imply that the line below in not neccessary
+	# So I commented it out for now
+#	LOD_variants[index].spawned_spatial = variant
 	pass
 
 
@@ -299,6 +303,7 @@ func reset_member_spatials():
 
 
 # Make sure LODs in OctreeNodes correspond to their active_LOD_index
+# This is the preffered way to 'refresh' MMIs inside OctreeNodes
 func set_LODs_to_active_index():
 	root_octree_node.set_LODs_to_active_index()
 

--- a/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
@@ -255,6 +255,7 @@ func assign_LOD_variant(max_LOD_index:int, LOD_max_distance:float, LOD_kill_dist
 	# But non-leaves do not have an MMI and can't spawn spatials
 	if is_leaf:
 		MMI.multimesh.mesh = shared_LOD_variants[LOD_index].mesh
+		MMI.cast_shadow = shared_LOD_variants[LOD_index].shadow_casting_mode
 		clear_and_spawn_all_member_spatials(last_LOD_index)
 
 

--- a/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
@@ -183,6 +183,8 @@ func set_LODs_to_active_index():
 				# Assign the LOD variant mesh
 				MMI.multimesh.mesh = new_mesh
 				clear_and_spawn_all_member_spatials(active_LOD_index)
+			# Update cast_shadow as well
+			MMI.cast_shadow = shared_LOD_variants[active_LOD_index].cast_shadow
 		else:
 			# Reset members
 			reset_members()
@@ -255,7 +257,7 @@ func assign_LOD_variant(max_LOD_index:int, LOD_max_distance:float, LOD_kill_dist
 	# But non-leaves do not have an MMI and can't spawn spatials
 	if is_leaf:
 		MMI.multimesh.mesh = shared_LOD_variants[LOD_index].mesh
-		MMI.cast_shadow = shared_LOD_variants[LOD_index].shadow_casting_mode
+		MMI.cast_shadow = shared_LOD_variants[LOD_index].cast_shadow
 		clear_and_spawn_all_member_spatials(last_LOD_index)
 
 
@@ -461,7 +463,7 @@ func reset_member_spatials():
 # This is used to update spatials in case their LOD variant changes
 func clear_and_spawn_all_member_spatials(last_LOD_index:int = -1):
 	# Here we compare spawned_spatials before and after changing an LOD index
-	# We they're the same - no need to update the spawned_spatials
+	# When they're the same - no need to update the spawned_spatials
 	# But first, make sure our shared_LOD_variants actually contain that index
 	if shared_LOD_variants.size() > last_LOD_index && last_LOD_index >= 0:
 		# Then compare spawned_spatials themselves

--- a/addons/dreadpon.spatial_gardener/gardener/gardener.gd
+++ b/addons/dreadpon.spatial_gardener/gardener/gardener.gd
@@ -308,6 +308,8 @@ func start_editing(__base_control:Control, __resource_previewer, __undoRedo:Undo
 	
 	for i in range(0, arborist.octree_managers.size()):
 		arborist.emit_member_count(i)
+	# Make sure LOD_Variants in a shared Octree array are up-to-date
+	set_refresh_octree_shared_LOD_variants(true)
 
 
 # Stop editing (painting) a scene
@@ -442,9 +444,9 @@ func on_greenhouse_prop_action_executed_on_LOD_variant(prop_action:PropAction, f
 		"spawned_spatial":
 			if prop_action is PA_PropSet || prop_action is PA_PropEdit:
 				arborist.on_LOD_variant_prop_changed_spawned_spatial(plant_index, mesh_index, final_val)
-		"shadow_casting_mode":
+		"cast_shadow":
 			if prop_action is PA_PropSet || prop_action is PA_PropEdit:
-				arborist.recenter_octree(plant_state, plant_index) #to force a refresh
+				arborist.set_LODs_to_active_index(plant_index)
 
 
 # A request to reconfigure an octree

--- a/addons/dreadpon.spatial_gardener/gardener/gardener.gd
+++ b/addons/dreadpon.spatial_gardener/gardener/gardener.gd
@@ -442,6 +442,9 @@ func on_greenhouse_prop_action_executed_on_LOD_variant(prop_action:PropAction, f
 		"spawned_spatial":
 			if prop_action is PA_PropSet || prop_action is PA_PropEdit:
 				arborist.on_LOD_variant_prop_changed_spawned_spatial(plant_index, mesh_index, final_val)
+		"shadow_casting_mode":
+			if prop_action is PA_PropSet || prop_action is PA_PropEdit:
+				arborist.recenter_octree(plant_state, plant_index) #to force a refresh
 
 
 # A request to reconfigure an octree

--- a/addons/dreadpon.spatial_gardener/greenhouse/greenhouse_LOD_variant.gd
+++ b/addons/dreadpon.spatial_gardener/greenhouse/greenhouse_LOD_variant.gd
@@ -12,9 +12,8 @@ var Globals = preload("../utility/globals.gd")
 
 var mesh:Mesh = null
 var spawned_spatial:PackedScene = null
-
-#Toggle for shadow casting mode on multimeshes
-var shadow_casting_mode:int = GeometryInstance.SHADOW_CASTING_SETTING_ON
+# Toggle for shadow casting mode on multimeshes
+var cast_shadow:int = GeometryInstance.SHADOW_CASTING_SETTING_ON
 
 
 
@@ -54,9 +53,9 @@ func _create_input_field(_base_control:Control, _resource_previewer, prop:String
 				"_resource_previewer": _resource_previewer,
 				}
 			input_field = UI_IF_ThumbnailObject.new(spawned_spatial, "Spawned Spatial", prop, settings)
-		"shadow_casting_mode":
-			var settings := {"enum_list": ["Off", "On"]}
-			input_field = UI_IF_Enum.new(shadow_casting_mode, "Shadow Casting Mode", prop, settings)
+		"cast_shadow":
+			var settings := {"enum_list": ["Off", "On", "Double-Sided", "Shadows Only"]}
+			input_field = UI_IF_Enum.new(cast_shadow, "Shadow Casting Mode", prop, settings)
 	
 	return input_field
 
@@ -77,8 +76,8 @@ func _set(prop, val):
 			mesh = val
 		"spawned_spatial":
 			spawned_spatial = val
-		"shadow_casting_mode":
-			shadow_casting_mode = val
+		"cast_shadow":
+			cast_shadow = val
 		_:
 			return_val = false
 	
@@ -94,8 +93,8 @@ func _get(prop):
 			return mesh
 		"spawned_spatial":
 			return spawned_spatial
-		"shadow_casting_mode":
-			return shadow_casting_mode
+		"cast_shadow":
+			return cast_shadow
 	
 	return null
 
@@ -105,7 +104,7 @@ func _get_property_list():
 	var props := [
 			prop_dict["mesh"],
 			prop_dict["spawned_spatial"],
-			prop_dict["shadow_casting_mode"]
+			prop_dict["cast_shadow"]
 		]
 	
 	return props
@@ -125,13 +124,13 @@ func _get_prop_dictionary():
 			"usage": PROPERTY_USAGE_DEFAULT,
 			"hint": PROPERTY_HINT_NONE,
 		},
-		"shadow_casting_mode":
+		"cast_shadow":
 		{
-			"name": "shadow_casting_mode",
+			"name": "cast_shadow",
 			"type": TYPE_INT,
 			"usage": PROPERTY_USAGE_DEFAULT,
 			"hint": PROPERTY_HINT_ENUM,
-			"hint_string": "Off,On"
+			"hint_string": "Off,On,Double-Sided,Shadows Only"
 		}
 	}
 
@@ -150,7 +149,7 @@ func get_prop_tooltip(prop:String) -> String:
 				+ "But if all your LODs reference the same PackedScene - they will persist across the LOD changes and won't cause any lag spikes\n" \
 				+ "The alternative would be to optimise yout octrees to contain only a small amount of Spawned Spatials - 10-20 at most\n" \
 				+ "Then the process of switching LODs will go a lot smoother"
-		"shadow_casting_mode":
-			return "Whether this specific LOD is enabled for shadow casting\n" \
-				+ "Disabling slightly improves performance and is recommended for higher LODs (far away)"
+		"cast_shadow":
+			return "Shadow casting mode for this specific LOD\n" \
+				+ "Disabling shadow casting slightly improves performance and is recommended for higher LODs (those further away)"
 	return ""

--- a/addons/dreadpon.spatial_gardener/greenhouse/greenhouse_LOD_variant.gd
+++ b/addons/dreadpon.spatial_gardener/greenhouse/greenhouse_LOD_variant.gd
@@ -13,6 +13,8 @@ var Globals = preload("../utility/globals.gd")
 var mesh:Mesh = null
 var spawned_spatial:PackedScene = null
 
+#Toggle for shadow casting mode on multimeshes
+var shadow_casting_mode:int = GeometryInstance.SHADOW_CASTING_SETTING_ON
 
 
 
@@ -52,6 +54,9 @@ func _create_input_field(_base_control:Control, _resource_previewer, prop:String
 				"_resource_previewer": _resource_previewer,
 				}
 			input_field = UI_IF_ThumbnailObject.new(spawned_spatial, "Spawned Spatial", prop, settings)
+		"shadow_casting_mode":
+			var settings := {"enum_list": ["Off", "On"]}
+			input_field = UI_IF_Enum.new(shadow_casting_mode, "Shadow Casting Mode", prop, settings)
 	
 	return input_field
 
@@ -72,6 +77,8 @@ func _set(prop, val):
 			mesh = val
 		"spawned_spatial":
 			spawned_spatial = val
+		"shadow_casting_mode":
+			shadow_casting_mode = val
 		_:
 			return_val = false
 	
@@ -87,6 +94,8 @@ func _get(prop):
 			return mesh
 		"spawned_spatial":
 			return spawned_spatial
+		"shadow_casting_mode":
+			return shadow_casting_mode
 	
 	return null
 
@@ -96,6 +105,7 @@ func _get_property_list():
 	var props := [
 			prop_dict["mesh"],
 			prop_dict["spawned_spatial"],
+			prop_dict["shadow_casting_mode"]
 		]
 	
 	return props
@@ -115,6 +125,14 @@ func _get_prop_dictionary():
 			"usage": PROPERTY_USAGE_DEFAULT,
 			"hint": PROPERTY_HINT_NONE,
 		},
+		"shadow_casting_mode":
+		{
+			"name": "shadow_casting_mode",
+			"type": TYPE_INT,
+			"usage": PROPERTY_USAGE_DEFAULT,
+			"hint": PROPERTY_HINT_ENUM,
+			"hint_string": "Off,On"
+		}
 	}
 
 
@@ -132,5 +150,7 @@ func get_prop_tooltip(prop:String) -> String:
 				+ "But if all your LODs reference the same PackedScene - they will persist across the LOD changes and won't cause any lag spikes\n" \
 				+ "The alternative would be to optimise yout octrees to contain only a small amount of Spawned Spatials - 10-20 at most\n" \
 				+ "Then the process of switching LODs will go a lot smoother"
-	
+		"shadow_casting_mode":
+			return "Whether this specific LOD is enabled for shadow casting\n" \
+				+ "Disabling slightly improves performance and is recommended for higher LODs (far away)"
 	return ""


### PR DESCRIPTION
Cleaned up the cast_shadow suggestion,  added missing options (double-sided, shadows only) and changed how we refresh an octree after an updated LOD_Variants.