### PR TITLE
Update Gardener icon for hi-dpi screens

### DIFF
--- a/addons/dreadpon.spatial_gardener/icons/gardener_icon.svg
+++ b/addons/dreadpon.spatial_gardener/icons/gardener_icon.svg
@@ -1,18 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 24.1.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 viewBox="0 0 16 16" style="enable-background:new 0 0 16 16;" xml:space="preserve">
-<style type="text/css">
-	.st0{fill:#EE7778;}
-	.st1{fill:none;stroke:#EE7778;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;}
-	.st2{fill:none;stroke:#EE7778;stroke-width:1.5;stroke-miterlimit:10;}
-</style>
-<path class="st0" d="M8,9.6c0,0,0,2.2,3.7,2.2c2.3,0,2.6,1.6,2.3,2.1c-2.9-0.7-4,1.1-5.9,1.1S5,13.3,2.1,14
-	c-0.3-0.6-0.1-2.1,2.3-2.1C8,11.9,8,9.6,8,9.6z"/>
-<g>
-	<path class="st1" d="M7.9,11.2c0.5-1.3,0.3-2.8-0.5-3.9"/>
-	<path class="st2" d="M10.8,5.3c-0.4,0.4-0.7,0.9-0.8,1.5c0.5,0.3,1.1,0.4,1.7,0.3c1-0.2,2.1-2.1,2.1-2.1S11.6,4.7,10.8,5.3z"/>
-	<path class="st2" d="M6.8,4.9C6.2,3.8,5,3.9,3.5,3.3C3,3.1,2.5,2.8,2.1,2.4C1.9,2.8,1.8,3.3,1.8,3.8C1.4,5.3,2.2,6.9,3.6,7.5
-		C5.1,8.2,6.8,7.8,7,7.4C7.4,6.6,7.4,5.7,6.8,4.9z"/>
-</g>
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linecap:round;stroke-linejoin:round" viewBox="0 0 32 32"><path d="M16 19.2s0 4.4 7.4 4.4c4.6 0 5.2 3.2 4.6 4.2-5.8-1.4-8 2.2-11.8 2.2s-6.2-3.4-12-2c-.6-1.2-.2-4.2 4.6-4.2 7.2 0 7.2-4.6 7.2-4.6" style="fill:#ee7778;fill-rule:nonzero"/><path d="M15.8 22.4c1-2.6.6-5.6-1-7.8" style="fill:none;fill-rule:nonzero;stroke:#ee7778;stroke-width:3px"/><path d="M21.6 10.6c-.8.8-1.4 1.8-1.6 3 1 .6 2.2.8 3.4.6 2-.4 4.2-4.2 4.2-4.2s-4.4-.6-6 .6ZM13.6 9.8C12.4 7.6 10 7.8 7 6.6c-1-.4-2-1-2.8-1.8-.4.8-.6 1.8-.6 2.8-.8 3 .8 6.2 3.6 7.4 3 1.4 6.4.6 6.8-.2.8-1.6.8-3.4-.4-5Z" style="fill:none;fill-rule:nonzero;stroke:#ee7778;stroke-width:3px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:10"/></svg>


### PR DESCRIPTION
Hello 👋 

I've resized `gardener_icon.svg` from 16x16px to 32x32px to make the icon appear correctly on higher DPIs.

# Changes

- resized gardener SVG icon from 16x16 to 32x32 and optimize with [SVGO](https://github.com/svg/svgo)

# Screenshots

## 100% UI Scale (No breaking changes)

| Before (16x16) | After (32x32) |
| --- | --- |
| ![Before 16x16 100% UI Scale](https://github.com/user-attachments/assets/816c5977-428b-479b-ba17-f8d7fcb83598) |  ![After 32x32 100% UI Scale](https://github.com/user-attachments/assets/775aa358-eece-48f5-aab1-748d3000b417) |

## 150% UI Scale

| Before (16x16) | After (32x32) |
| --- | --- |
| ![Before 16x16 150% UI Scale](https://github.com/user-attachments/assets/3864cd0b-9aac-4108-b4a4-0249576cbcc4) |  ![After 32x32 150% UI Scale](https://github.com/user-attachments/assets/870eb893-4fad-4dd1-a513-e976c5afba46) |

## 200% UI Scale

| Before (16x16) | After (32x32) |
| --- | --- |
| ![Before 16x16 200% UI Scale](https://github.com/user-attachments/assets/70015ca5-b05b-472c-8e82-bdbccbdabe1d) |  ![After 32x32 200% UI Scale](https://github.com/user-attachments/assets/7f692a26-627c-4e5c-8f66-a27ebfcaebb4) |


![image](https://github.com/user-attachments/assets/37c75fb6-61f1-4302-ba2c-c437510fde90)
