### PR TITLE
4.5 Patch - Adjustment to how loading leaves in the octree works

### DIFF
--- a/addons/dreadpon.spatial_gardener/arborist/arborist.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/arborist.gd
@@ -15,7 +15,7 @@ extends Resource
 # However, these functions are very closely related, so maybe I'm overthinking this
 
 
-const Logger = preload("../utility/logger.gd")
+const CustomLogger = preload("../utility/logger.gd")
 const Globals = preload("../utility/globals.gd")
 const FunLib = preload("../utility/fun_lib.gd")
 const Greenhouse_Plant = preload("../greenhouse/greenhouse_plant.gd")
@@ -84,7 +84,7 @@ signal transplanted_member(plant_index: int, new_address: PackedByteArray, new_i
 func _init():
 	set_meta("class", "Arborist")
 	resource_local_to_scene = true
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	mutex_octree = Mutex.new()
 	mutex_LOD_update_meta = Mutex.new()
 	thread_LOD_update = Thread.new()

--- a/addons/dreadpon.spatial_gardener/arborist/brush_placement_area.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/brush_placement_area.gd
@@ -55,7 +55,7 @@ extends RefCounted
 
 const Globals = preload("../utility/globals.gd")
 const FunLib = preload("../utility/fun_lib.gd")
-const Logger = preload("../utility/logger.gd")
+const CustomLogger = preload("../utility/logger.gd")
 const MMIOctreeManager = preload("mmi_octree/mmi_octree_manager.gd")
 const MMIOctreeNode = preload("mmi_octree/mmi_octree_node.gd")
 
@@ -91,7 +91,7 @@ var logger = null
 
 
 func _init(__sphere_pos:Vector3,__sphere_radius:float,__plane_normal:Vector3,__jitter_fraction:float = 0.6):
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	sphere_pos = __sphere_pos
 	sphere_radius = __sphere_radius
 	sphere_diameter = sphere_radius * 2.0

--- a/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
@@ -138,24 +138,33 @@ func restore_after_load(__gardener_root:Node3D, LOD_variants:Array):
 	gardener_root = __gardener_root
 	shared_LOD_variants = LOD_variants
 	
-	# NOTE: Theoretically this would not be needed if we could be sure no outdated OctreeNodes were used
-	#		We can't be because of different Storage Versions
 	max_bounds_to_center_dist = sqrt(pow(extent, 2) * 3)
 	min_bounds_to_center_dist = extent
 	
+	# FIX: Recalculate is_leaf based on actual child_nodes state
+	var should_be_leaf = child_nodes.is_empty()
+	if is_leaf != should_be_leaf:
+		print("FIXING is_leaf corruption at ", get_address(), ": was ", is_leaf, ", should be ", should_be_leaf)
+		set_is_leaf(should_be_leaf)
+	
 	if !is_instance_valid(leaf):
 		leaf = OctreeLeaf.new()
+		leaf.set_octree_node(self)
 	
 	if shared_LOD_variants.size() <= active_LOD_index:
 		_set_active_LOD_index_skip_leaf(shared_LOD_variants.size() - 1)
 	
-	# No need to explicitly call on_active_lod_index_changed, since it's accounted for in restore_after_load
 	leaf.restore_after_load() 
 	_set_active_LOD_index(0, false)
 
-	for child in child_nodes:
-		child.parent = self
-		child.restore_after_load(__gardener_root, LOD_variants)
+	# FIX: Restore child octant values (they're getting corrupted on save)
+	for i in range(child_nodes.size()):
+		child_nodes[i].parent = self
+		# Fix corrupted octant index (should be 0-7, but might be -1 or 255)
+		if child_nodes[i].octant < 0 or child_nodes[i].octant > 7:
+			child_nodes[i].octant = i
+			print("FIXING octant corruption: child ", i, " had invalid octant ", child_nodes[i].octant)
+		child_nodes[i].restore_after_load(__gardener_root, LOD_variants)
 	
 	print_address("", "restored after load")
 

--- a/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/mmi_octree/mmi_octree_node.gd
@@ -13,7 +13,7 @@ extends Resource
 
 
 const FunLib = preload("../../utility/fun_lib.gd")
-const Logger = preload("../../utility/logger.gd")
+const CustomLogger = preload("../../utility/logger.gd")
 const Placeform = preload("../placeform.gd")
 const OctreeLeaf = preload("octree_leaf.gd")
 const Greenhouse_LODVariant = preload("../../greenhouse/greenhouse_LOD_variant.gd")
@@ -69,7 +69,7 @@ func _init(__parent:Resource = null, __max_members:int = 0, __extent:float = 0.0
 	set_meta("class", "MMIOctreeNode")
 	resource_name = "MMIOctreeNode"
 	
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	
 	max_members = __max_members
 	child_nodes.clear()

--- a/addons/dreadpon.spatial_gardener/arborist/stroke_handler/stroke_handler.gd
+++ b/addons/dreadpon.spatial_gardener/arborist/stroke_handler/stroke_handler.gd
@@ -7,7 +7,7 @@ extends RefCounted
 #-------------------------------------------------------------------------------
 
 
-const Logger = preload("../../utility/logger.gd")
+const CustomLogger = preload("../../utility/logger.gd")
 const FunLib = preload("../../utility/fun_lib.gd")
 const DponDebugDraw = preload("../../utility/debug_draw.gd")
 const Greenhouse_Plant = preload("../../greenhouse/greenhouse_plant.gd")
@@ -58,7 +58,7 @@ func _init(_brush:Toolshed_Brush, _plant_states:Array, _octree_managers:Array, _
 	
 	randomizer = RandomNumberGenerator.new()
 	randomizer.seed = Time.get_ticks_msec()
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	
 	debug_draw_enabled 			= FunLib.get_setting_safe("dreadpons_spatial_gardener/debug/stroke_handler_debug_draw", true)
 	simplify_projection_frustum = FunLib.get_setting_safe("dreadpons_spatial_gardener/painting/simplify_projection_frustum", true)

--- a/addons/dreadpon.spatial_gardener/controls/input_fields/ui_input_field.gd
+++ b/addons/dreadpon.spatial_gardener/controls/input_fields/ui_input_field.gd
@@ -15,7 +15,7 @@ extends PanelContainer
 
 const ThemeAdapter = preload("../theme_adapter.gd")
 const FunLib = preload("../../utility/fun_lib.gd")
-const Logger = preload("../../utility/logger.gd")
+const CustomLogger = preload("../../utility/logger.gd")
 const PropAction = preload("../../utility/input_field_resource/prop_action.gd")
 const PA_PropSet = preload("../../utility/input_field_resource/pa_prop_set.gd")
 const PA_PropEdit = preload("../../utility/input_field_resource/pa_prop_edit.gd")
@@ -71,7 +71,7 @@ signal prop_action_requested(prop_action)
 func _init(__init_val, __labelText:String = "NONE", __prop_name:String = "", settings:Dictionary = {}, tooltip:String = ""):
 	set_meta("class", "UI_InputField")
 	
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	init_val = __init_val
 	prop_name = __prop_name
 	

--- a/addons/dreadpon.spatial_gardener/gardener/data_import_export.gd
+++ b/addons/dreadpon.spatial_gardener/gardener/data_import_export.gd
@@ -1,6 +1,6 @@
 extends RefCounted
 
-const Logger = preload("../utility/logger.gd")
+const CustomLogger = preload("../utility/logger.gd")
 const Globals = preload("../utility/globals.gd")
 const FunLib = preload("../utility/fun_lib.gd")
 const Defaults = preload("../utility/defaults.gd")
@@ -25,7 +25,7 @@ var toolshed: Toolshed = null
 
 
 func _init(_arborist: Arborist, _greenhouse: Greenhouse, _toolshed: Toolshed = null):
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	arborist = _arborist
 	greenhouse = _greenhouse
 	toolshed = _toolshed

--- a/addons/dreadpon.spatial_gardener/gardener/gardener.gd
+++ b/addons/dreadpon.spatial_gardener/gardener/gardener.gd
@@ -14,7 +14,7 @@ extends Node3D
 
 
 const FunLib = preload("../utility/fun_lib.gd")
-const Logger = preload("../utility/logger.gd")
+const CustomLogger = preload("../utility/logger.gd")
 const Defaults = preload("../utility/defaults.gd")
 const Greenhouse = preload("../greenhouse/greenhouse.gd")
 const Toolshed = preload("../toolshed/toolshed.gd")
@@ -113,7 +113,7 @@ static func get_storage_ver():
 func _ready():
 	update_plugin_ver()
 	
-	logger = Logger.get_for(self, name)
+	logger = CustomLogger.get_for(self, name)
 	
 	painting_node = Node3D.new()
 	add_child(painting_node, true, Node.INTERNAL_MODE_FRONT)
@@ -232,7 +232,7 @@ func propagate_camera(camera:Camera3D):
 # This is supposed to address a problem decribed in "start_gardener_edit()" of "plugin.gd"
 # Instead of recalculating everything, we hope it's enough to just restore the member references
 func restore_references():
-	logger = Logger.get_for(self, name)
+	logger = CustomLogger.get_for(self, name)
 	if !Engine.is_editor_hint(): return
 	
 	init_painter()

--- a/addons/dreadpon.spatial_gardener/plugin.gd
+++ b/addons/dreadpon.spatial_gardener/plugin.gd
@@ -9,7 +9,7 @@ extends EditorPlugin
 #-------------------------------------------------------------------------------
 
 
-const Logger = preload("utility/logger.gd")
+const CustomLogger = preload("utility/logger.gd")
 const Globals = preload("utility/globals.gd")
 const FunLib = preload("utility/fun_lib.gd")
 const ProjectSettingsManager = preload("utility/project_settings_manager.gd")
@@ -74,7 +74,7 @@ func _ready():
 	
 	if !Engine.is_editor_hint(): return
 	
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 
 	if Engine.is_editor_hint():
 		undo_redo = get_undo_redo()

--- a/addons/dreadpon.spatial_gardener/scene_converter/converters/base_ver_converter.gd
+++ b/addons/dreadpon.spatial_gardener/scene_converter/converters/base_ver_converter.gd
@@ -3,7 +3,7 @@ extends RefCounted
 enum RunMode {RECREATE, DRY, CONVERT}
 
 const Types = preload('../converter_types.gd')
-var Logger = preload('../../utility/logger.gd')
+var CustomLogger = preload('../../utility/logger.gd')
 
 var logger
 
@@ -11,7 +11,7 @@ var logger
 
 
 func _init():
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 
 
 func convert_gardener(parsed_scene: Array, run_mode: int, ext_res: Dictionary, sub_res: Dictionary):

--- a/addons/dreadpon.spatial_gardener/scene_converter/scene_converter.gd
+++ b/addons/dreadpon.spatial_gardener/scene_converter/scene_converter.gd
@@ -45,7 +45,7 @@ const C_1_To_2 = preload('converters/c_1_to_2.gd')
 const C_3_To_4 = preload('converters/c_3_to_4.gd')
 const FunLib = preload("../utility/fun_lib.gd")
 const Gardener = preload("../gardener/gardener.gd")
-const Logger = preload('../utility/logger.gd')
+const CustomLogger = preload('../utility/logger.gd')
 const ConvertDialog_SCN = preload("convert_dialog.tscn")
 
 const number_char_list = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '.', '-']
@@ -209,7 +209,7 @@ func add_scene_file(file_path: String, scenes: Array):
 
 func _run_conversion(in_filepaths: Array, mk_backups: bool = true, out_base_dir: String = '') -> bool:
 	var timestamp = Time.get_datetime_string_from_system(false, true).replace(' ', '_').replace(':', '.')
-	logger = Logger.get_for(self, '', 'user://sg_tscn_conversion_%s.txt' % [timestamp])
+	logger = CustomLogger.get_for(self, '', 'user://sg_tscn_conversion_%s.txt' % [timestamp])
 	
 	logger.info('Found %d valid scenes for conversion' % [in_filepaths.size()])
 	

--- a/addons/dreadpon.spatial_gardener/utility/fun_lib.gd
+++ b/addons/dreadpon.spatial_gardener/utility/fun_lib.gd
@@ -6,7 +6,7 @@
 #-------------------------------------------------------------------------------
 
 
-const Logger = preload("logger.gd")
+const CustomLogger = preload("logger.gd")
 const Globals = preload("globals.gd")
 enum TimeTrimMode {NONE, EXACT, EXTRA_ONE, KEEP_ONE, KEEP_TWO, KEEP_THREE}
 
@@ -303,7 +303,7 @@ static func get_setting_safe(setting:String, default_value = null):
 
 static func save_res(res:Resource, dir:String, res_name:String):
 	assert(res)
-	var logger = Logger.get_for_string("FunLib")
+	var logger = CustomLogger.get_for_string("FunLib")
 	var full_path = combine_dir_and_file(dir, res_name)
 	if !is_dir_valid(dir): 
 		logger.warn("Unable to save '%s', directory is invalid!" % [full_path])
@@ -332,7 +332,7 @@ static func save_res(res:Resource, dir:String, res_name:String):
 static func load_res(dir:String, res_name:String, no_cache: bool = true, silent: bool = false) -> Resource:
 	var full_path = combine_dir_and_file(dir, res_name)
 	var res = null
-	var logger = Logger.get_for_string("FunLib")
+	var logger = CustomLogger.get_for_string("FunLib")
 	
 	if ResourceLoader.exists(full_path):
 		res = ResourceLoader.load(full_path, "", ResourceLoader.CacheMode.CACHE_MODE_REPLACE if no_cache else ResourceLoader.CacheMode.CACHE_MODE_REUSE)
@@ -351,7 +351,7 @@ static func remove_res(dir:String, res_name:String):
 	var full_path = combine_dir_and_file(dir, res_name)
 	var abs_path = ProjectSettings.globalize_path(full_path)
 	var err = DirAccess.remove_absolute(abs_path)
-	var logger = Logger.get_for_string("FunLib")
+	var logger = CustomLogger.get_for_string("FunLib")
 	if err != OK:
 		logger.error("Could not remove '%s', error %s!" % [abs_path, Globals.get_err_message(err)])
 

--- a/addons/dreadpon.spatial_gardener/utility/input_field_resource/input_field_resource.gd
+++ b/addons/dreadpon.spatial_gardener/utility/input_field_resource/input_field_resource.gd
@@ -16,7 +16,7 @@ extends Resource
 enum PropActionLifecycle {BEFORE_DO, AFTER_DO, AFTER_UNDO}
 
 
-const Logger = preload("../logger.gd")
+const CustomLogger = preload("../logger.gd")
 const FunLib = preload("../fun_lib.gd")
 
 const PropAction = preload("prop_action.gd")
@@ -77,7 +77,7 @@ signal prop_list_changed(prop_names)
 func _init():
 	set_meta("class", "InputFieldResource")
 	resource_name = "InputFieldResource"
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	FunLib.ensure_signal(self.prop_action_executed, _on_prop_action_executed)
 
 

--- a/addons/dreadpon.spatial_gardener/utility/project_settings_manager.gd
+++ b/addons/dreadpon.spatial_gardener/utility/project_settings_manager.gd
@@ -8,7 +8,7 @@
 
 const Globals = preload("globals.gd")
 const FunLib = preload("fun_lib.gd")
-const Logger = preload("logger.gd")
+const CustomLogger = preload("logger.gd")
 
 
 
@@ -143,7 +143,7 @@ static func add_plugin_project_settings():
 	# Saving settings
 	var err: int = ProjectSettings.save()
 	if err:
-		var logger = Logger.get_for_string("ProjectSettingsManager")
+		var logger = CustomLogger.get_for_string("ProjectSettingsManager")
 		logger.error("Encountered error %s when saving project settings" % [Globals.get_err_message(err)])
 
 

--- a/testing/tests/test_base.gd
+++ b/testing/tests/test_base.gd
@@ -4,7 +4,7 @@ extends Node
 
 const GenericUtils = preload("../utility/generic_utils.gd")
 const Global = preload("res://addons/dreadpon.spatial_gardener/utility/globals.gd")
-const Logger = preload("res://addons/dreadpon.spatial_gardener/utility/logger.gd")
+const CustomLogger = preload("res://addons/dreadpon.spatial_gardener/utility/logger.gd")
 const FunLib = preload("res://addons/dreadpon.spatial_gardener/utility/fun_lib.gd")
 const UndoRedoInterface = preload("res://addons/dreadpon.spatial_gardener/utility/undo_redo_interface.gd")
 
@@ -22,7 +22,7 @@ signal finished_undo_redo_action(current_action_index)
 
 
 func _init():
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 	dpon_testing_set_undo_redo(UndoRedo.new())
 
 

--- a/testing/utility/greenhouse_creator.gd
+++ b/testing/utility/greenhouse_creator.gd
@@ -7,7 +7,7 @@ const Greenhouse = preload("res://addons/dreadpon.spatial_gardener/greenhouse/gr
 const Toolshed = preload("res://addons/dreadpon.spatial_gardener/toolshed/toolshed.gd")
 const PlantUtils = preload("plant_utils.gd")
 const GenericUtils = preload("generic_utils.gd")
-const Logger = preload("res://addons/dreadpon.spatial_gardener/utility/logger.gd")
+const CustomLogger = preload("res://addons/dreadpon.spatial_gardener/utility/logger.gd")
 const Globals = preload("res://addons/dreadpon.spatial_gardener/utility/globals.gd")
 const FunLib = preload("res://addons/dreadpon.spatial_gardener/utility/fun_lib.gd")
 
@@ -27,7 +27,7 @@ var logger = null
 func _init():
 	greenhouses = []
 	toolsheds = []
-	logger = Logger.get_for(self)
+	logger = CustomLogger.get_for(self)
 
 
 func set_greenhouses(val):


### PR DESCRIPTION
Just a follow-up to PR [#76](https://github.com/dreadpon/godot_spatial_gardener/pull/76) where Logger was changed to CustomLogger

This is a fix for #78 

Had to do with the change of duplication in 4.5.

When a node has is_leaf = true BUT also has child_nodes, the OctreeLeaf thinks it should manage instances, but the node is actually supposed to delegate to children. This creates the desync.

In mmi_octree_node.gd, in restore_after_load(), I forced recalculation of is_leaf based on actual state instead of assuming it. It's not performant, but it works for 4.5 testing on a full game (where I have tons and tons of meshes and scenes)