### PR TITLE
Import/Export bug fix - Check if _replace_dialog exists before hiding

### DIFF
--- a/addons/dreadpon.spatial_gardener/greenhouse/greenhouse.gd
+++ b/addons/dreadpon.spatial_gardener/greenhouse/greenhouse.gd
@@ -291,7 +291,8 @@ func on_replace_dialog_custom_action(action: String, file_path: String, is_impor
 
 
 func on_req_import_export_file_confirmed(file_path: String, is_import: bool, is_plant_data: bool, replace_data: bool, plant_idx: int = -1):
-	_replace_dialog.hide()
+	if _replace_dialog:	
+		_replace_dialog.hide()
 	if is_import:
 		if is_plant_data:
 			req_import_plant_data.emit(file_path, plant_idx, replace_data)


### PR DESCRIPTION
This failed if _replace_dialog was never created before exporting, making exporting fail relatively silently. This just fixes that and makes sure import/export works every time. 

Tested on 4.6 with PR #80  